### PR TITLE
Add GHA to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,7 @@ updates:
       - dependency-name: "@polkadot/util-crypto"
     labels:
       - "dependencies"
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily


### PR DESCRIPTION
This PR adds GitHub Actions monitoring to the Dependabot

Related issues:
https://github.com/paritytech/ci_cd/issues/407
https://github.com/paritytech/ci_cd/issues/464